### PR TITLE
Make role re-use easier

### DIFF
--- a/roles_revamp.md
+++ b/roles_revamp.md
@@ -25,7 +25,7 @@ Roles lack flexibility in execution and inclusion.
         - role: myrole
           exec_main: no
 ```
-- Expand includes to be able to execute 'role tasks' in 'role context'.
+- Expand includes to be able to execute 'role tasks' in 'role context'. This will work within plays and within role tasks. The role's variables are added to the current context, the role's files are added to the search path, etc.
 ```    
     - include: main.yml
         role: myrole
@@ -34,4 +34,23 @@ Roles lack flexibility in execution and inclusion.
       vars:
          var1: val1
 ```
-  This allows for a more controlled execution and easier reuse of roles and it's resources.
+
+- Allow the default of `exec_main` to be overridden by a role in its `meta/main.yml` so it doesn't have to be specified each time a role is invoked
+
+- In `meta/main.yml` allow a role to depend on another with variable scope and file search path inheritance. Unlike specfying  an include via `exec_main: no` at the start of the role's execution, this sets the included roles variables before the including role's so the including role can reference the included role's variables in its defaults, etc. This also avoids the need to duplicate the same role import in all of a role's `tasks/` YML files. e.g.
+```
+  dependencies:
+    - { role: postgres_server, inherit: true }
+```
+
+  This provides for a primitive form of inheritance, where one role can use another as a base and extend it. A role for a server with apache configured with ldap auth and a postgres database could inherit apache2, ldap and postgres roles then do the work required to configure them to talk to each other, and it'd be able to reference the other roles' tasks like `restart_apache.yml` when doing so. (Currently to do this you have to explicitly use paths to the other roles' tasks and will have issues with variable scoping/availability).
+
+- To make this more convenient to use within playbooks, when a role is referenced in a play a non-default task may be specified for the role. This task is run after the role's `main.yml` if `exec_main` is true, otherwise instead of `main.yml`. The suffix `.yml` is added implicitly if not specified. e.g.
+```
+- hosts: somehosts
+  roles:
+    - { role: postgres_server, ansible_task: install }
+```
+  would include role bdrnodes, check its `meta/main.yml` for `exec_main`, run `roles/postgres_server/tasks/main.yml` if `exec_main` is not false, then run `roles/postgres_server/tasks/install.yml` . The `ansible_` prefix is used to try to avoid clashes with existing user variables named "task".
+
+This allows for a more controlled execution and easier reuse of roles and it's resources.


### PR DESCRIPTION
The existing proposal provides the foundation needed, but will be somewhat repetitive and prone to lots of boilerplate.

I think it's strongly desirable to make `exec_main` a role meta attribute so you don't have to specify it each time. To avoid the need to do the include-the-other-role dance in a role's tasks, meta role dependencies should be extended to declaratively include the other role's vars and task/templates search path. And to make it easier to actually use this, an option to run a different task via the `roles:` stanza in the playbook should be incorporated.

See edits in commit.

Right now, a "role" in Ansible is more like an encapsulated task with some vars and files bundled with it. It doesn't really describe a server role at all. If you have a "postgres" server, you need roles for "postgres_install", "postgres_restart", "postgres_start", "postgres_stop", etc to usefully use it in plays. These roles are then difficult to use from other roles, because when you depend on a role it executes once, before the depending role, and doesn't add its files to the depending role's search path. You land up doing a lot of cross-role 'include'ing and hard coding paths a lot. So if "myapp" needs apache and postgres, but it has to restart apache partway through setup and it also needs a specific postgres extension that requires myapp-specific setup, the myapp role lands up very messy or you land up with a play like:

```
roles:
  - {role: apache_install }
  - {role: apache_start }
  - {role: postgres_install }
  - {role: postgres_start }
  - {role: myapp_install_phase1 }
  - {role: postgres_restart }
  - {role: myapp_install_phase2 }
  ...
```

which is incredibly unwieldy and makes "role" a misnomer. You can use conditionals to reduce role fragmentation somewhat, but at the cost of littering your roles with lots of conditions everywhere, and getting tons of "skipped" output in plays.

The idea here is to make roles more easily represent what their name makes them sound like: an actual "role" for a server, a part of its functionality. Make them composeable, so if you have a "postgres" role, an "apache" role, an "ldap auth" role and a "myapp" role, you can compose the "postgres" and "apache" and "ldap auth" roles into the foundation on which the "myapp" role depends and deploys. "myapp" can use the apache role to find the apache config files, restart apache after changing its configuration, etc, because it has access to all the apache role's vars, templates, handlers and tasks.

Combined with the recent improvements to handlers this will make role re-use much more practical and role composition possible.
